### PR TITLE
Fixes #6 Added SimpleSaveIgnoreAttribute to replace ReadOnlyAttribute…

### DIFF
--- a/src/Dapper.SimpleSave/Dapper.SimpleSave.csproj
+++ b/src/Dapper.SimpleSave/Dapper.SimpleSave.csproj
@@ -82,6 +82,7 @@
     <Compile Include="ReadOnlyAttribute.cs" />
     <Compile Include="ReferenceDataAttribute.cs" />
     <Compile Include="SimpleSaveExtensions.cs" />
+    <Compile Include="SimpleSaveIgnoreAttribute.cs" />
     <Compile Include="SoftDeleteColumnAttribute.cs" />
     <Compile Include="TableAttribute.cs" />
   </ItemGroup>

--- a/src/Dapper.SimpleSave/PropertyMetadata.cs
+++ b/src/Dapper.SimpleSave/PropertyMetadata.cs
@@ -51,7 +51,7 @@ namespace Dapper.SimpleSave
 
         public bool IsReadOnly
         {
-            get { return HasAttribute<ReadOnlyAttribute>() || ! Prop.CanWrite;}
+            get { return HasAttribute<SimpleSaveIgnoreAttribute>() || ! Prop.CanWrite;}
         }
 
         public bool IsPublic

--- a/src/Dapper.SimpleSave/ReadOnlyAttribute.cs
+++ b/src/Dapper.SimpleSave/ReadOnlyAttribute.cs
@@ -2,6 +2,7 @@
 
 namespace Dapper.SimpleSave
 {
+    [Obsolete("Use of this attribute is deprecated because its name is confusing/misleading when used on a property that has both a getter and setter, such as a convenience property. Please use SimpleSaveIgnoreAttributeInstead", true)]
     public class ReadOnlyAttribute : Attribute
     {
     }

--- a/src/Dapper.SimpleSave/SimpleSaveIgnoreAttribute.cs
+++ b/src/Dapper.SimpleSave/SimpleSaveIgnoreAttribute.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace Dapper.SimpleSave
+{
+    public class SimpleSaveIgnoreAttribute : Attribute
+    {
+    }
+}


### PR DESCRIPTION
…. Made ReadOnlyAttribute obsolete, and made it an error to use it, rather than deleting straight away and added error telling people to use the new type. Once that's been in for a few weeks, I'll get rid of ReadOnlyAttribute.