### PR TITLE
Made DtoMetadataCache public so it can be shared with Dapper.SimpleLo…

### DIFF
--- a/src/Dapper.SimpleSave/DtoMetadata.cs
+++ b/src/Dapper.SimpleSave/DtoMetadata.cs
@@ -18,7 +18,7 @@ namespace Dapper.SimpleSave
 
         public Type DtoType { get; set; }
 
-        public string TableName { get; set; }
+        public string TableName { get; private set; }
 
         public bool IsReferenceData
         {

--- a/src/Dapper.SimpleSave/SimpleSaveExtensions.cs
+++ b/src/Dapper.SimpleSave/SimpleSaveExtensions.cs
@@ -10,7 +10,7 @@ namespace Dapper.SimpleSave
 {
     public static class SimpleSaveExtensions
     {
-        private static readonly DtoMetadataCache _dtoMetadataCache = new DtoMetadataCache();
+        public static readonly DtoMetadataCache _dtoMetadataCache = new DtoMetadataCache();
 
         private static ISimpleSaveLogger _logger = new BasicSimpleSaveLogger();
 


### PR DESCRIPTION
…ad. Also made TableName setter private because there's no need for it to be public.