### PR TITLE
Develop

### DIFF
--- a/src/Dapper.SimpleSave.Tests/GuidManyToManyRelationshipCommandGenerationTests.cs
+++ b/src/Dapper.SimpleSave.Tests/GuidManyToManyRelationshipCommandGenerationTests.cs
@@ -19,7 +19,7 @@ namespace Dapper.SimpleSave.Tests {
             Assert.AreEqual(cache.GetMetadataFor(typeof(GuidParentDto)).TableName, command.Operation.ValueMetadata.TableName, "Unexpected table name");
             command = list [1] as InsertCommand;
             Assert.AreEqual(
-                cache.GetMetadataFor(typeof(GuidParentDto)).Properties.Where(p => p.ColumnName == manyToManyPropertyName).FirstOrDefault().GetAttribute<ManyToManyAttribute>().SchemaQualifiedLinkTableName,
+                cache.GetMetadataFor(typeof(GuidParentDto)).WriteableProperties.Where(p => p.ColumnName == manyToManyPropertyName).FirstOrDefault().GetAttribute<ManyToManyAttribute>().SchemaQualifiedLinkTableName,
                 command.Operation.OwnerPropertyMetadata.GetAttribute<ManyToManyAttribute>().SchemaQualifiedLinkTableName, "Unexpected table name");
         }
 
@@ -179,7 +179,7 @@ namespace Dapper.SimpleSave.Tests {
                 "Unexpected number of operations.");
 
             Assert.AreEqual(
-                cache.GetMetadataFor(typeof(GuidParentDto)).Properties.Where(p => p.ColumnName == "ParentName").FirstOrDefault().ColumnName,
+                cache.GetMetadataFor(typeof(GuidParentDto)).WriteableProperties.Where(p => p.ColumnName == "ParentName").FirstOrDefault().ColumnName,
                 command.Operations.FirstOrDefault().ColumnName,
                 "Unexpected column name.");
         }

--- a/src/Dapper.SimpleSave.Tests/ManyToManyRelationshipCommandGenerationTests.cs
+++ b/src/Dapper.SimpleSave.Tests/ManyToManyRelationshipCommandGenerationTests.cs
@@ -19,7 +19,7 @@ namespace Dapper.SimpleSave.Tests {
             Assert.AreEqual(cache.GetMetadataFor(typeof(ParentDto)).TableName, command.Operation.ValueMetadata.TableName, "Unexpected table name");
             command = list [1] as InsertCommand;
             Assert.AreEqual(
-                cache.GetMetadataFor(typeof(ParentDto)).Properties.Where(p => p.ColumnName == manyToManyPropertyName).FirstOrDefault().GetAttribute<ManyToManyAttribute>().SchemaQualifiedLinkTableName,
+                cache.GetMetadataFor(typeof(ParentDto)).WriteableProperties.Where(p => p.ColumnName == manyToManyPropertyName).FirstOrDefault().GetAttribute<ManyToManyAttribute>().SchemaQualifiedLinkTableName,
                 command.Operation.OwnerPropertyMetadata.GetAttribute<ManyToManyAttribute>().SchemaQualifiedLinkTableName, "Unexpected table name");
         }
 
@@ -174,7 +174,7 @@ namespace Dapper.SimpleSave.Tests {
                 "Unexpected number of operations.");
 
             Assert.AreEqual(
-                cache.GetMetadataFor(typeof(ParentDto)).Properties.Where(p => p.ColumnName == "ParentName").FirstOrDefault().ColumnName,
+                cache.GetMetadataFor(typeof(ParentDto)).WriteableProperties.Where(p => p.ColumnName == "ParentName").FirstOrDefault().ColumnName,
                 command.Operations.FirstOrDefault().ColumnName,
                 "Unexpected column name.");
         }

--- a/src/Dapper.SimpleSave/DtoMetadata.cs
+++ b/src/Dapper.SimpleSave/DtoMetadata.cs
@@ -18,7 +18,7 @@ namespace Dapper.SimpleSave
 
         public Type DtoType { get; set; }
 
-        public string TableName { get; set; }
+        public string TableName { get; private set; }
 
         public bool IsReferenceData
         {

--- a/src/Dapper.SimpleSave/Impl/Differ.cs
+++ b/src/Dapper.SimpleSave/Impl/Differ.cs
@@ -144,7 +144,7 @@ namespace Dapper.SimpleSave.Impl
                 return;
             }
 
-            foreach (var prop in metadata.Properties)
+            foreach (var prop in metadata.WriteableProperties)
             {
                 if (metadata.IsReferenceData && !prop.HasAttribute<ForeignKeyReferenceAttribute>())
                 {

--- a/src/Dapper.SimpleSave/Impl/OperationBuilder.cs
+++ b/src/Dapper.SimpleSave/Impl/OperationBuilder.cs
@@ -207,7 +207,7 @@ namespace Dapper.SimpleSave.Impl
 
         private bool HasAnyOneToOneChildrenWithFKOnParent(DeleteOperation deleteOperation)
         {
-            foreach (var property in deleteOperation.ValueMetadata.Properties)
+            foreach (var property in deleteOperation.ValueMetadata.WriteableProperties)
             {
                 if (property.IsOneToOneRelationship && property.HasAttribute<ForeignKeyReferenceAttribute>())
                 {

--- a/src/Dapper.SimpleSave/Impl/ScriptBuilder.cs
+++ b/src/Dapper.SimpleSave/Impl/ScriptBuilder.cs
@@ -276,7 +276,7 @@ WHERE [{1}] = ",
                     var values = new ArrayList();
                     var index = 0;
 
-                    foreach (var property in operation.ValueMetadata.Properties)
+                    foreach (var property in operation.ValueMetadata.WriteableProperties)
                     {
                         if (property.IsPrimaryKey)
                         {

--- a/src/Dapper.SimpleSave/SimpleSaveExtensions.cs
+++ b/src/Dapper.SimpleSave/SimpleSaveExtensions.cs
@@ -10,7 +10,7 @@ namespace Dapper.SimpleSave
 {
     public static class SimpleSaveExtensions
     {
-        private static readonly DtoMetadataCache _dtoMetadataCache = new DtoMetadataCache();
+        public static readonly DtoMetadataCache MetadataCache = new DtoMetadataCache();
 
         private static ISimpleSaveLogger _logger = new BasicSimpleSaveLogger();
 
@@ -142,7 +142,7 @@ namespace Dapper.SimpleSave
             bool softDelete = false,
             IDbTransaction transaction = null)
         {
-            var builder = new TransactionBuilder(_dtoMetadataCache);
+            var builder = new TransactionBuilder(MetadataCache);
             IDictionary<Tuple<T, T>, IList<Script>> scripts = new Dictionary<Tuple<T, T>, IList<Script>>();
             foreach (var pair in oldAndNewObjects)
             {
@@ -299,7 +299,7 @@ namespace Dapper.SimpleSave
             PropertyMetadata softDeletePropertyMetadata = null;
             if (softDelete)
             {
-                var metadata = _dtoMetadataCache.GetMetadataFor<T>();
+                var metadata = MetadataCache.GetMetadataFor<T>();
                 if (newRootObject == null && oldRootObject != null)
                 {
                     softDeletePropertyMetadata = SoftDeleteValidator.GetValidatedSoftDeleteProperty(metadata);


### PR DESCRIPTION
Now exports full list of properties, as well as just writeable properties (from SimpleSave's perspective), from metadata cache, enabling SimpleLoad to work off of the former list.